### PR TITLE
fix: impl std Error for StartError

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -183,6 +189,7 @@ dependencies = [
 name = "lassie"
 version = "0.1.1"
 dependencies = [
+ "anyhow",
  "cc",
  "env_logger",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ build = "build.rs"
 log = "0.4.17"
 
 [dev-dependencies]
+anyhow = "1.0.71"
 env_logger = "0.10.0"
 pretty_assertions = "1.3.0"
 ureq = "2.6.2"

--- a/src/start_error.rs
+++ b/src/start_error.rs
@@ -1,0 +1,54 @@
+use std::fmt::{Display, Formatter};
+use std::path::PathBuf;
+
+#[derive(Debug, PartialEq, Clone)]
+#[non_exhaustive]
+pub enum StartError {
+    MutexPoisoned,
+    OnlyOneInstanceAllowed,
+    PathContainsNullByte(String),
+    PathIsNotValidUtf8(PathBuf),
+    Lassie(String),
+}
+
+impl Display for StartError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        write!(f, "failed to start Lassie daemon: ")?;
+        match self {
+            StartError::MutexPoisoned => f.write_str("the global mutex was poisoned"),
+            StartError::OnlyOneInstanceAllowed => {
+                f.write_str("cannot create more than one instance")
+            }
+            StartError::PathContainsNullByte(path_str) => f.write_fmt(format_args!(
+                "null bytes are not allowed in paths (value: {:?})",
+                path_str
+            )),
+            StartError::PathIsNotValidUtf8(path) => f.write_fmt(format_args!(
+                "path that are not valid UTF-8 are not supported (value: {:?})",
+                path.display(),
+            )),
+            StartError::Lassie(msg) => f.write_str(msg),
+        }
+    }
+}
+
+impl std::error::Error for StartError {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use anyhow::Context;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn can_be_converted_to_anyhow_error() {
+        let result: Result<(), StartError> = Err(StartError::OnlyOneInstanceAllowed);
+        let anyhow = result.context("lassie error");
+        // the test passes when the compiler does not complain about the line above
+        // to double check, we are also asserting on the string representation
+        assert_eq!(
+            format!("{:#}", anyhow.unwrap_err()),
+            format!("lassie error: {}", StartError::OnlyOneInstanceAllowed)
+        );
+    }
+}


### PR DESCRIPTION
Also extract `StartError` code into a standalone file.

After this change, we can use anyhow's `context` extension to convert `StartError` instances to `anyhow` instances.


