### PR TITLE
fix: support `log` version `^0.4.17`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log = "0.4.18"
+log = "0.4.17"
 
 [dev-dependencies]
 anyhow = "1.0.71"


### PR DESCRIPTION
The crate `deno_core` locks `log` version to `0.4.17`. Before this change, lassie was requiring `log` version `^0.4.18`, which was preventing Deno projects like Zinnia from using lassie.

This commit changes the minimum required `log` version to `0.4.17`.
