### PR TITLE
chore: let Dependabot ignore new `log` versions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,6 +11,10 @@ updates:
       prefix-development: "deps(dev)"
     reviewers:
       - "bajtos"
+    ignore:
+      # Keep the `log` crate at version ^0.17.0 to stay compatible with
+      # Deno crates that are pinning `log` version exactly to `0.17.0`
+      - dependency-name: "log"
 
   - package-ecosystem: "gomod"
     directory: "/go-lib"

--- a/.github/workflows/dependabot-validation.yml
+++ b/.github/workflows/dependabot-validation.yml
@@ -6,7 +6,7 @@ name: Validate Dependabot config
 on:
   pull_request:
     paths:
-      - '.github/dependabot.yml'
+      - '.github/dependabot.yaml'
       - '.github/workflows/dependabot-validation.yml'
 jobs:
   validate:


### PR DESCRIPTION
This is a follow-up for #11.