### PR TITLE
chore: exclude large images from Cargo package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/filecoin-station/rusty-lassie"
 authors = [
     "Miroslav Bajtoš <oss@bajtos.net>"
 ]
+exclude = [
+    "docs/images/logo-square.png",
+    "docs/images/logo-rectangle.jpg",
+]
 
 build = "build.rs"
 


### PR DESCRIPTION
Before:
 - Packaged 27 files, 12.8MiB (12.4MiB compressed)

After:
 - Packaged 24 files, 1.3MiB (1.2MiB compressed)
