### PR TITLE
fix: cross-compilation using Cross

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -131,3 +131,38 @@ jobs:
             echo "PR title is too long (greater than 72 characters)"
             exit 1
           fi
+
+  cross-compile:
+    name: Cross-compile fof ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-gnu
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@52e69531e6f69a396bc9d1226284493a5db969ff # v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+
+      - name: Setup Cross
+        run: |
+          curl -L https://github.com/cross-rs/cross/releases/latest/download/cross-x86_64-unknown-linux-gnu.tar.gz -o /tmp/cross.tgz
+          tar xzf /tmp/cross.tgz -C ~/.cargo/bin
+          cross --version
+
+      - name: Cache Rust deps
+        uses: Swatinem/rust-cache@988c164c3d0e93c4dbab36aaf5bbeb77425b2894 # v2.4.0
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        with:
+          shared-key: cross-${{ matrix.target }}
+          cache-on-failure: true
+
+      - name: Build
+        run: cross build --all --locked --target ${{ matrix.target }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,7 +133,7 @@ jobs:
           fi
 
   cross-compile:
-    name: Cross-compile fof ${{ matrix.target }}
+    name: Cross-compile for ${{ matrix.target }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -140,7 +140,9 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
+            test: true
           - target: aarch64-unknown-linux-gnu
+            test: false
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -165,4 +167,10 @@ jobs:
           cache-on-failure: true
 
       - name: Build
-        run: cross build --all --locked --target ${{ matrix.target }}
+        run: cross build --all-targets --target ${{ matrix.target }}
+
+      - name: Test
+        if: matrix.test == 'true'
+        run: cross test --target ${{ matrix.target }}
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ go.work
 ########
 
 go-lib/_obj
+target/go

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,3 @@ go.work
 ########
 
 go-lib/_obj
-target/go

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,9 @@
+[target.x86_64-unknown-linux-gnu]
+pre-build = [
+    "rm -rf /usr/local/go && curl -L https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -xz -C /usr/local && ln -s /usr/local/go/bin/go /usr/local/bin/ && go version"
+]
+
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+    "rm -rf /usr/local/go && curl -L https://go.dev/dl/go1.20.5.linux-arm64.tar.gz | tar -xz -C /usr/local && ln -s /usr/local/go/bin/go /usr/local/bin/ && go version"
+]

--- a/Cross.toml
+++ b/Cross.toml
@@ -5,5 +5,7 @@ pre-build = [
 
 [target.aarch64-unknown-linux-gnu]
 pre-build = [
+    # Cross is always running the container on `amd64`, therefore you must download `amd64` version
+    # of Go when targeting `aarch64`.
     "rm -rf /usr/local/go && curl -L https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -xz -C /usr/local && ln -s /usr/local/go/bin/go /usr/local/bin/ && go version"
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,7 +1,6 @@
 [target.x86_64-unknown-linux-gnu]
 dockerfile = "cross/Dockerfile"
 
-
 [target.aarch64-unknown-linux-gnu]
 dockerfile = "cross/Dockerfile"
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -5,5 +5,5 @@ pre-build = [
 
 [target.aarch64-unknown-linux-gnu]
 pre-build = [
-    "rm -rf /usr/local/go && curl -L https://go.dev/dl/go1.20.5.linux-arm64.tar.gz | tar -xz -C /usr/local && ln -s /usr/local/go/bin/go /usr/local/bin/ && go version"
+    "rm -rf /usr/local/go && curl -L https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -xz -C /usr/local && ln -s /usr/local/go/bin/go /usr/local/bin/ && go version"
 ]

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,11 +1,7 @@
 [target.x86_64-unknown-linux-gnu]
-pre-build = [
-    "rm -rf /usr/local/go && curl -L https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -xz -C /usr/local && ln -s /usr/local/go/bin/go /usr/local/bin/ && go version"
-]
+dockerfile = "cross/Dockerfile"
+
 
 [target.aarch64-unknown-linux-gnu]
-pre-build = [
-    # Cross is always running the container on `amd64`, therefore you must download `amd64` version
-    # of Go when targeting `aarch64`.
-    "rm -rf /usr/local/go && curl -L https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -xz -C /usr/local && ln -s /usr/local/go/bin/go /usr/local/bin/ && go version"
-]
+dockerfile = "cross/Dockerfile"
+

--- a/README.md
+++ b/README.md
@@ -88,6 +88,33 @@ Rusty-Lassie's build script copies the DLL into the target directory next to the
 main executable. All you need is to include this DLL in your distribution
 archive.
 
+## Cross-compilation
+
+If you are building your project using
+[Cross](https://github.com/cross-rs/cross), you need to install Go in the Docker
+images used by Cross.
+
+For example, you can add a `Cross.toml` file with the following content to your
+project root (replace the Go version as needed):
+
+```toml
+[target.x86_64-unknown-linux-gnu]
+pre-build = [
+  "rm -rf /usr/local/go && curl -L https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -xz -C /usr/local && ln -s /usr/local/go/bin/go /usr/local/bin/ && go version"
+]
+
+[target.aarch64-unknown-linux-gnu]
+pre-build = [
+  "rm -rf /usr/local/go && curl -L https://go.dev/dl/go1.20.5.linux-arm64.tar.gz | tar -xz -C /usr/local && ln -s /usr/local/go/bin/go /usr/local/bin/ && go version"
+]
+```
+
+Learn more in Cross and Go documentation:
+
+- [Configuring cross via a Cross.toml file](https://github.com/cross-rs/cross#option-2-configuring-cross-via-a-crosstoml-file)
+- [Pre-build hook](https://github.com/cross-rs/cross#pre-build-hook)
+- [Download and install Go](https://go.dev/doc/install)
+
 ## License
 
 This library is dual-licensed under Apache 2.0 and MIT terms.

--- a/README.md
+++ b/README.md
@@ -94,23 +94,7 @@ If you are building your project using
 [Cross](https://github.com/cross-rs/cross), you need to install Go in the Docker
 images used by Cross.
 
-For example, you can add a `Cross.toml` file with the following content to your
-project root:
-
-```toml
-[target.x86_64-unknown-linux-gnu]
-pre-build = [
-  "rm -rf /usr/local/go && curl -L https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -xz -C /usr/local && ln -s /usr/local/go/bin/go /usr/local/bin/ && go version"
-]
-
-[target.aarch64-unknown-linux-gnu]
-pre-build = [
-  "rm -rf /usr/local/go && curl -L https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -xz -C /usr/local && ln -s /usr/local/go/bin/go /usr/local/bin/ && go version"
-]
-```
-
-Cross is always running the container on `amd64`, therefore you must download
-`amd64` version of Go when targeting `aarch64`.
+Check out our own [Cross.toml](./Cross.toml) for inspiration.
 
 Learn more in Cross and Go documentation:
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you are building your project using
 images used by Cross.
 
 For example, you can add a `Cross.toml` file with the following content to your
-project root (replace the Go version as needed):
+project root:
 
 ```toml
 [target.x86_64-unknown-linux-gnu]
@@ -105,9 +105,12 @@ pre-build = [
 
 [target.aarch64-unknown-linux-gnu]
 pre-build = [
-  "rm -rf /usr/local/go && curl -L https://go.dev/dl/go1.20.5.linux-arm64.tar.gz | tar -xz -C /usr/local && ln -s /usr/local/go/bin/go /usr/local/bin/ && go version"
+  "rm -rf /usr/local/go && curl -L https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -xz -C /usr/local && ln -s /usr/local/go/bin/go /usr/local/bin/ && go version"
 ]
 ```
+
+Cross is always running the container on `amd64`, therefore you must download
+`amd64` version of Go when targeting `aarch64`.
 
 Learn more in Cross and Go documentation:
 

--- a/README.md
+++ b/README.md
@@ -94,12 +94,13 @@ If you are building your project using
 [Cross](https://github.com/cross-rs/cross), you need to install Go in the Docker
 images used by Cross.
 
-Check out our own [Cross.toml](./Cross.toml) for inspiration.
+Check out our own [Cross.toml](./Cross.toml) and
+[cross/Dockerfile](./cross/Dockerfile) for inspiration.
 
 Learn more in Cross and Go documentation:
 
 - [Configuring cross via a Cross.toml file](https://github.com/cross-rs/cross#option-2-configuring-cross-via-a-crosstoml-file)
-- [Pre-build hook](https://github.com/cross-rs/cross#pre-build-hook)
+- [Dockerfiles](https://github.com/cross-rs/cross#dockerfiles)
 - [Download and install Go](https://go.dev/doc/install)
 
 ## License

--- a/build.rs
+++ b/build.rs
@@ -48,6 +48,14 @@ fn build_lassie() {
 
         cmd.env("GOCACHE", format!("{target_dir}/go/cache"))
             .env("GOMODCACHE", format!("{target_dir}/go/pkg-mod-cache"));
+
+        if arch == "aarch64" {
+            // Overwrite Go CC config, unless it's already provided by the user
+            // See https://github.com/golang/go/issues/28966
+            if env::var("CC").is_err() {
+                cmd.env("CC", "aarch64-linux-gnu-gcc");
+            }
+        }
     }
 
     let status = cmd.status().expect(

--- a/build.rs
+++ b/build.rs
@@ -23,8 +23,8 @@ fn build_lassie() {
 
     eprintln!("Building {out_file} for {arch} (GOARCH={goarch})");
 
-    let status = Command::new("go")
-        .current_dir("go-lib")
+    let mut cmd = Command::new("go");
+    cmd.current_dir("go-lib")
         .args([
             "build",
             "-tags",
@@ -37,9 +37,22 @@ fn build_lassie() {
         .env("GOARCH", goarch)
         // We must explicitly enable CGO when cross-compiling
         // See e.g. https://stackoverflow.com/q/74976549/69868
-        .env("CGO_ENABLED", "1")
-        .status()
-        .expect("Cannot execute `go`, make sure it's installed.\nLearn more at https://go.dev/doc/install");
+        .env("CGO_ENABLED", "1");
+
+    if env::var("HOME") == Ok("/".to_string()) && env::var("CROSS_RUNNER").is_ok() {
+        // When cross-compiling using `cross build`, HOME is set to `/` and go is trying to
+        // create its cache dir in /.cache/go-build, which is not writable.
+        // We fix the problem by explicitly setting the GOCACHE and GOMODCACHE env vars
+        let target_dir = env::var("CARGO_TARGET_DIR")
+            .expect("cannot obtain CARGO_TARGET_DIR from the environment");
+
+        cmd.env("GOCACHE", format!("{target_dir}/go/cache"))
+            .env("GOMODCACHE", format!("{target_dir}/go/pkg-mod-cache"));
+    }
+
+    let status = cmd.status().expect(
+        "Cannot execute `go`, make sure it's installed.\nLearn more at https://go.dev/doc/install",
+    );
     assert!(status.success(), "`go build` failed");
 
     println!("cargo:rustc-link-search=native={out_dir}");

--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -1,7 +1,7 @@
 ARG CROSS_BASE_IMAGE
 FROM $CROSS_BASE_IMAGE
 
-RUN rm -rf /usr/local/go;
+RUN rm -rf /usr/local/go
 RUN curl -L https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -xz -C /usr/local
 
 ENV PATH /usr/local/go/bin:$PATH

--- a/cross/Dockerfile
+++ b/cross/Dockerfile
@@ -1,0 +1,9 @@
+ARG CROSS_BASE_IMAGE
+FROM $CROSS_BASE_IMAGE
+
+RUN rm -rf /usr/local/go;
+RUN curl -L https://go.dev/dl/go1.20.5.linux-amd64.tar.gz | tar -xz -C /usr/local
+
+ENV PATH /usr/local/go/bin:$PATH
+# Verify that `go` is in the path
+RUN go version


### PR DESCRIPTION
Modify the build script to fix GOCACHE and GOMODCACHE and let them point to a directory we can write to. Cross sets HOME to root (/), which is read-only for the user running the build.

This should fix the error I am observing in https://github.com/filecoin-station/zinnia/pull/248, see also https://github.com/filecoin-station/roadmap/issues/19