### PR TITLE
feat: expose additional Lassie configuration options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,7 @@ pub struct DaemonConfig {
     /// MaxBlocks optionally specifies the maximum number of blocks to fetch.
     ///
     /// When the requested CID contains more blocks than specified, the HTTP response will be
-    /// aborted in a way that trigger a client error.
+    /// aborted in a way that triggers a client error.
     pub max_blocks: Option<u64>,
 
     /// Specify a custom timeout for retrieving data from a provider. Beyond this limit, when no

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,9 +103,16 @@ fn get_global_daemon() -> std::sync::LockResult<MutexGuard<'static, Option<GoDae
     unsafe { DAEMON.lock() }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct DaemonConfig {
+    /// Directory where to store temporary files (CAR store).
+    ///
+    /// By default, Lassie stores temporary files in the OS-specific temp directory.
     pub temp_dir: Option<PathBuf>,
+
+    /// Port where to listen.
+    ///
+    /// By default, we ask the operating system to choose a free ephemeral port.
     pub port: u16,
 
     /// MaxBlocks optionally specifies the maximum number of blocks to fetch.
@@ -122,7 +129,8 @@ pub struct DaemonConfig {
     ///
     /// On timeout, the HTTP response will be aborted in a way that triggers a client error.
     ///
-    /// The default value is 20 seconds.
+    /// The default timeout is controlled by Go version of Lassie and you should not rely on any
+    /// particular value. Provide your own value if this timeout is important for you.
     pub provider_timeout: Option<Duration>,
 
     /// Specify a custom timeout for the entire retrieval process.
@@ -131,18 +139,6 @@ pub struct DaemonConfig {
     ///
     /// No timeout is enforced by default.
     pub global_timeout: Option<Duration>,
-}
-
-impl Default for DaemonConfig {
-    fn default() -> Self {
-        Self {
-            temp_dir: Default::default(),
-            port: Default::default(),
-            max_blocks: Default::default(),
-            provider_timeout: Some(Duration::from_secs(20)),
-            global_timeout: Some(Duration::from_secs(20)),
-        }
-    }
 }
 
 pub struct Daemon {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,17 +109,27 @@ pub struct DaemonConfig {
     pub port: u16,
 
     /// MaxBlocks optionally specifies the maximum number of blocks to fetch.
+    ///
+    /// When the requested CID contains more blocks than specified, the HTTP response will be
+    /// aborted in a way that trigger a client error.
     pub max_blocks: Option<u64>,
 
     /// Specify a custom timeout for retrieving data from a provider. Beyond this limit, when no
     /// data has been received, the retrieval will fail.
+    ///
+    /// At the moment, this configuration applies to Bitswap retrievals only and controls how
+    /// much time we allow for the storage provider to send us the next block.
+    ///
+    /// On timeout, the HTTP response will be aborted in a way that triggers a client error.
     ///
     /// The default value is 20 seconds.
     pub provider_timeout: Option<Duration>,
 
     /// Specify a custom timeout for the entire retrieval process.
     ///
-    /// The default value is 20 seconds.
+    /// On timeout, the HTTP response will be aborted in a way that triggers a client error.
+    ///
+    /// No timeout is enforced by default.
     pub global_timeout: Option<Duration>,
 }
 

--- a/src/start_error.rs
+++ b/src/start_error.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
+use std::time::Duration;
 
 #[derive(Debug, PartialEq, Clone)]
 #[non_exhaustive]
@@ -8,6 +9,7 @@ pub enum StartError {
     OnlyOneInstanceAllowed,
     PathContainsNullByte(String),
     PathIsNotValidUtf8(PathBuf),
+    DurationIsTooLong(Duration),
     Lassie(String),
 }
 
@@ -27,6 +29,9 @@ impl Display for StartError {
                 path.display(),
             )),
             StartError::Lassie(msg) => f.write_str(msg),
+            StartError::DurationIsTooLong(d) => f.write_fmt(format_args!(
+                "duration {d:#?} is too long, Go limits the largest representable duration to approximately 290 years",
+            )),
         }
     }
 }


### PR DESCRIPTION
Add three new configuration options, see the API docs for their description:

- `max_blocks`
- `provider_timeout`
- `global_timeout`
