### PR TITLE
feat: add `access_token` configuration

### DIFF
--- a/go-lib/lassie-ffi.go
+++ b/go-lib/lassie-ffi.go
@@ -18,6 +18,7 @@ typedef struct {
 	uint64_t max_blocks;
 	int64_t provider_timeout;
 	int64_t global_timeout;
+	const char* access_token;
 } daemon_config_t;
 
 typedef struct {
@@ -77,12 +78,18 @@ func InitDaemon(cfg *C.daemon_config_t) C.daemon_init_result_t {
 	}
 
 	var tempDir string = C.GoString(cfg.temp_dir)
+	accessToken := C.GoString(cfg.access_token)
+
 	if debug_log_enabled {
-		tempDirStr := "`" + tempDir + "`"
+		tempDirStr := fmt.Sprintf("`%s`", tempDir)
 		if tempDir == "" {
 			tempDirStr = "<empty>"
 		}
-		debug(fmt.Sprintf("Lassie configuration:\n  log_level=%d\n  port=%d\n  temp_dir=`%v`", cfg.log_level, cfg.port, tempDirStr))
+		accessTokenStr := fmt.Sprintf("`%s`", accessToken)
+		if accessToken == "" {
+			accessTokenStr = "<not configured>"
+		}
+		debug(fmt.Sprintf("Lassie configuration:\n  log_level=%d\n  port=%d\n  temp_dir=%v\n  accessToken=%v", cfg.log_level, cfg.port, tempDirStr, accessTokenStr))
 	}
 
 	lassieOpts := []lassie.LassieOption{
@@ -117,6 +124,7 @@ func InitDaemon(cfg *C.daemon_config_t) C.daemon_init_result_t {
 		Port:                uint(cfg.port),
 		TempDir:             tempDir,
 		MaxBlocksPerRequest: uint64(cfg.max_blocks),
+		AccessToken:         accessToken,
 	})
 
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/filecoin-station/rusty-lassie
 
 go 1.20
 
-require github.com/filecoin-project/lassie v0.13.0
+require github.com/filecoin-project/lassie v0.13.1-0.20230626222603-46c970bece1d
 
 require (
 	github.com/benbjohnson/clock v1.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -122,8 +122,8 @@ github.com/filecoin-project/go-statemachine v1.0.3/go.mod h1:jZdXXiHa61n4NmgWFG4
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-statestore v0.2.0 h1:cRRO0aPLrxKQCZ2UOQbzFGn4WDNdofHZoGPjfNaAo5Q=
 github.com/filecoin-project/go-statestore v0.2.0/go.mod h1:8sjBYbS35HwPzct7iT4lIXjLlYyPor80aU7t7a/Kspo=
-github.com/filecoin-project/lassie v0.13.0 h1:nNm2WUYEE1FO5duNY38W5HLPC3IqyMV754c+CGIgV90=
-github.com/filecoin-project/lassie v0.13.0/go.mod h1:kbO6Ljk/2ug6CLJuHsgsd4c6EVrAmnVQKFAktmETSI4=
+github.com/filecoin-project/lassie v0.13.1-0.20230626222603-46c970bece1d h1:l9ZvYqtTxowgfCCZpnO+LA7b/SMoUGQpZtmbpi/6P6Y=
+github.com/filecoin-project/lassie v0.13.1-0.20230626222603-46c970bece1d/go.mod h1:kbO6Ljk/2ug6CLJuHsgsd4c6EVrAmnVQKFAktmETSI4=
 github.com/filecoin-project/specs-actors v0.9.4/go.mod h1:BStZQzx5x7TmCkLv0Bpa07U6cPKol6fd3w9KjMPZ6Z4=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,14 +273,18 @@ fn try_convert_duration_to_go_type(from: Duration) -> Result<i64, StartError> {
     i64::try_from(from.as_nanos()).map_err(|_| StartError::DurationIsTooLong(from))
 }
 
+// Why we are disabling clippy::missing_panics_docs: This function never panics. The only `unwrap()`
+// call is on the line handling the `None` case and we know it's not going to panic because "" does
+// not contain any null bytes.
 #[allow(clippy::missing_panics_doc)]
-// ^^^ We know it's safe to unwrap because "" does not contain any null bytes
 fn access_token_as_cstring(access_token: Option<String>) -> Result<CString, StartError> {
     match access_token {
         Some(token) => {
             CString::new(token.clone()).map_err(|_| StartError::AccessTokenContainsNullByte(token))
         }
-        None => Ok(CString::new("").unwrap()),
+        None => Ok(CString::new("")
+            // This unwrap() never panics because "" does not contain any null bytes.
+            .unwrap()),
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,7 @@ struct GoDaemonConfig {
     max_blocks: u64,
     provider_timeout: i64,
     global_timeout: i64,
+    access_token: *const c_char,
 }
 
 struct GoDaemon {
@@ -139,6 +140,11 @@ pub struct DaemonConfig {
     ///
     /// No timeout is enforced by default.
     pub global_timeout: Option<Duration>,
+
+    /// Require retrieval requests to provide authorization header with the configured access token.
+    ///
+    /// For example: `Authorization: Bearer {token}`
+    pub access_token: Option<String>,
 }
 
 pub struct Daemon {
@@ -189,6 +195,8 @@ impl Daemon {
             None => 0,
         };
 
+        let access_token = access_token_as_cstring(config.access_token)?;
+
         let go_config = GoDaemonConfig {
             temp_dir: temp_dir.as_ptr(),
             log_level: log_level as usize,
@@ -196,6 +204,7 @@ impl Daemon {
             global_timeout,
             provider_timeout,
             max_blocks: config.max_blocks.unwrap_or(0),
+            access_token: access_token.as_ptr(),
         };
 
         // SAFETY:
@@ -262,6 +271,17 @@ impl Drop for Daemon {
 fn try_convert_duration_to_go_type(from: Duration) -> Result<i64, StartError> {
     // Go Duration type represents the elapsed time between two instants as an int64 nanosecond count.
     i64::try_from(from.as_nanos()).map_err(|_| StartError::DurationIsTooLong(from))
+}
+
+#[allow(clippy::missing_panics_doc)]
+// ^^^ We know it's safe to unwrap because "" does not contain any null bytes
+fn access_token_as_cstring(access_token: Option<String>) -> Result<CString, StartError> {
+    match access_token {
+        Some(token) => {
+            CString::new(token.clone()).map_err(|_| StartError::AccessTokenContainsNullByte(token))
+        }
+        None => Ok(CString::new("").unwrap()),
+    }
 }
 
 #[cfg(test)]

--- a/src/start_error.rs
+++ b/src/start_error.rs
@@ -11,6 +11,7 @@ pub enum StartError {
     PathIsNotValidUtf8(PathBuf),
     DurationIsTooLong(Duration),
     Lassie(String),
+    AccessTokenContainsNullByte(String),
 }
 
 impl Display for StartError {
@@ -31,6 +32,9 @@ impl Display for StartError {
             StartError::Lassie(msg) => f.write_str(msg),
             StartError::DurationIsTooLong(d) => f.write_fmt(format_args!(
                 "duration {d:#?} is too long, Go limits the largest representable duration to approximately 290 years",
+            )),
+            StartError::AccessTokenContainsNullByte(token) => f.write_fmt(format_args!(
+                "null bytes are not allowed in the access token (value: {token:?})",
             )),
         }
     }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -192,14 +192,12 @@ fn assert_ok_response(response: Result<ureq::Response, ureq::Error>) -> ureq::Re
 
 fn assert_response_status_code(response: Result<ureq::Response, ureq::Error>, expected_code: u16) {
     match response {
-        #[allow(clippy::manual_assert)]
         Err(ureq::Error::Status(code, response)) => {
-            if code != expected_code {
-                panic!(
-                    "Request failed with unexpected status code. Wanted: {expected_code} Found: {code}. Body:\n{}\n==EOF==",
-                    response.into_string().expect("cannot read response body"),
-                );
-            }
+            assert!(
+                code == expected_code,
+                "Request failed with unexpected status code. Wanted: {expected_code} Found: {code}. Body:\n{}\n==EOF==",
+                response.into_string().expect("cannot read response body"),
+            );
         }
 
         Err(err) => {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -121,7 +121,7 @@ fn it_rejects_anonymous_requests_when_configured_with_access_token() {
         .set("Accept", "application/vnd.ipld.car")
         .call();
 
-    assert_response_status_code(response, 401);
+    assert_response_error(response, 401);
 }
 
 #[test]
@@ -166,7 +166,7 @@ fn it_rejects_incorrect_authorization_when_configured_with_access_token() {
         .set("Authorization", "Bearer wrong-token")
         .call();
 
-    assert_response_status_code(response, 401);
+    assert_response_error(response, 401);
 }
 
 fn setup_test_env() -> MutexGuard<'static, ()> {
@@ -190,7 +190,7 @@ fn assert_ok_response(response: Result<ureq::Response, ureq::Error>) -> ureq::Re
     response
 }
 
-fn assert_response_status_code(response: Result<ureq::Response, ureq::Error>, expected_code: u16) {
+fn assert_response_error(response: Result<ureq::Response, ureq::Error>, expected_code: u16) {
     match response {
         Err(ureq::Error::Status(code, response)) => {
             assert!(
@@ -205,7 +205,7 @@ fn assert_response_status_code(response: Result<ureq::Response, ureq::Error>, ex
         }
 
         Ok(_response) => {
-            panic!("Request should have failed with 401 Unauthorized, it succeeded instead.");
+            panic!("Request should have failed with {expected_code}, it succeeded instead.");
         }
     }
 }


### PR DESCRIPTION
Allow Lassie consumers to enable authorization for all retrieval requests. When the configuration provides an access token, then all requests must include `Authorization` header using `Bearer` scheme, e.g. `Authorization: Bearer {token}`.

See https://github.com/filecoin-station/zinnia/issues/268
