### PR TITLE
ci: use Go version 1.20

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 'stable'
+          go-version: '1.20'
           cache-dependency-path: 'go-lib/go.sum'
 
       - uses: Swatinem/rust-cache@b8a6852b4f997182bdea832df3f9e153038b5191 # v2.6.0


### PR DESCRIPTION
Lassie and/or its dependencies don't support Go version 1.21 yet.
