### PR TITLE
fix: configure Lassie user-agent

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -147,9 +147,8 @@ fn get_lassie_version() -> String {
     let text = std::fs::read_to_string("go.sum").expect("cannot open go.sum");
 
     for ln in text.lines() {
-        if ln.starts_with(GO_SUM_LASSIE) {
-            let ln = &ln[GO_SUM_LASSIE.len()..];
-            match ln.split_once(' ') {
+        if let Some(spec) = ln.strip_prefix(GO_SUM_LASSIE) {
+            match spec.split_once(' ') {
                 Some((v, _)) => return v.to_owned(),
                 None => panic!("Malformed go.sum line: {ln}"),
             }

--- a/build.rs
+++ b/build.rs
@@ -7,11 +7,12 @@ fn main() {
     println!("cargo:rerun-if-changed=go-lib/lassie.go");
 
     let v = get_lassie_version();
-    assert_eq!(
-        v, "0.21.0",
-        "New Lassie version detected. Update the build version in build.rs."
-    );
-    println!("cargo:rustc-env=LASSIE_VERSION=0.21.0-2cf1121");
+    // assert_eq!(
+    //     v, "0.21.0",
+    //     "New Lassie version detected. Update the build version in build.rs."
+    // );
+    // println!("cargo:rustc-env=LASSIE_VERSION=0.21.0-2cf1121");
+    println!("cargo:rustc-env=LASSIE_VERSION={v}-rs");
 
     build_lassie();
 }

--- a/build.rs
+++ b/build.rs
@@ -3,8 +3,15 @@ use std::process::Command;
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rerun-if-changed=go-lib/go.sum");
+    println!("cargo:rerun-if-changed=go.sum");
     println!("cargo:rerun-if-changed=go-lib/lassie.go");
+
+    let v = get_lassie_version();
+    assert_eq!(
+        v, "0.21.0",
+        "New Lassie version detected. Update the build version in build.rs."
+    );
+    println!("cargo:rustc-env=LASSIE_VERSION=0.21.0-2cf1121");
 
     build_lassie();
 }
@@ -131,4 +138,22 @@ fn build_lassie() {
     let dll_out = format!("{out_dir}\\..\\..\\..\\golassie.dll");
     std::fs::copy(&out_file, &dll_out)
         .unwrap_or_else(|_| panic!("cannot copy {out_file} to {dll_out}"));
+}
+
+const GO_SUM_LASSIE: &str = "github.com/filecoin-project/lassie v";
+
+fn get_lassie_version() -> String {
+    let text = std::fs::read_to_string("go.sum").expect("cannot open go.sum");
+
+    for ln in text.lines() {
+        if ln.starts_with(GO_SUM_LASSIE) {
+            let ln = &ln[GO_SUM_LASSIE.len()..];
+            match ln.split_once(' ') {
+                Some((v, _)) => return v.to_owned(),
+                None => panic!("Malformed go.sum line: {ln}"),
+            }
+        }
+    }
+
+    panic!("lassie not found in go.sum file")
 }

--- a/go-lib/lassie-ffi.go
+++ b/go-lib/lassie-ffi.go
@@ -19,6 +19,7 @@ typedef struct {
 	int64_t provider_timeout;
 	int64_t global_timeout;
 	const char* access_token;
+	const char* lassie_user_agent;
 } daemon_config_t;
 
 typedef struct {
@@ -42,6 +43,7 @@ import (
 	"time"
 	"unsafe"
 
+	lassieBuild "github.com/filecoin-project/lassie/pkg/build"
 	"github.com/filecoin-project/lassie/pkg/lassie"
 	httpserver "github.com/filecoin-project/lassie/pkg/server/http"
 )
@@ -79,6 +81,7 @@ func InitDaemon(cfg *C.daemon_config_t) C.daemon_init_result_t {
 
 	var tempDir string = C.GoString(cfg.temp_dir)
 	accessToken := C.GoString(cfg.access_token)
+	lassieBuild.UserAgent = C.GoString(cfg.lassie_user_agent)
 
 	if debug_log_enabled {
 		tempDirStr := fmt.Sprintf("`%s`", tempDir)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -51,7 +51,7 @@ fn configure_max_blocks() {
     let _lock = setup_test_env();
 
     let daemon = Daemon::start(DaemonConfig {
-        max_blocks: Some(10),
+        max_blocks: Some(1),
         ..DaemonConfig::default()
     })
     .expect("cannot start Lassie");


### PR DESCRIPTION
Fix the user agent used by Rusty Lassie to report the version of the underlying Go Lassie library.

While we want to make SPARK retrievals as much indistinguishable from Saturn retrievals as possible to prevent SPs from prioritising serving SPARK over serving Saturn, we also need the ability to troubleshoot increased load on SPs in the short term.

Based on the discussion below, I decided to use a custom build version `-rs` in the user agent to distinguish Spark traffic from Saturn traffic.

```diff
- user-agent: lassie/v0.0.0-unknown
+ user-agent: lassie/v0.21.0-rs
```

